### PR TITLE
Gets DPR from cookie when unavailable in ClientHint header.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "retina"
   ],
   "homepage": "https://github.com/jonesiscoding/device",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "suggest": {
     "deviscoding/poly-pointer": "Psuedo-Polyfill for (pointer:coarse). Easy support of touch devices."
   },

--- a/src/Hints/Hint/DPR.php
+++ b/src/Hints/Hint/DPR.php
@@ -2,6 +2,8 @@
 
 namespace DevCoding\Hints\Hint;
 
+use DevCoding\Hints\Base\CookieHintInterface;
+use DevCoding\Hints\Base\CookieHintTrait;
 use DevCoding\Hints\Base\Hint;
 use DevCoding\Hints\Base\ConstantAwareInterface;
 
@@ -22,10 +24,13 @@ use DevCoding\Hints\Base\ConstantAwareInterface;
  *
  * @package DevCoding\Hints
  */
-class DPR extends Hint implements ConstantAwareInterface
+class DPR extends Hint implements CookieHintInterface, ConstantAwareInterface
 {
+  use CookieHintTrait;
+
   const HEADER     = 'Sec-CH-DPR';
   const ALTERNATES = ['DPR'];
+  const COOKIE     = 'dpr';
   const DEFAULT    = 1;
   const DRAFT      = false;
   const STATIC     = false;


### PR DESCRIPTION
`CookieHintInterface` and the cookie key were left out of the `DPR` hint class.